### PR TITLE
30921 - fix GraphQL response not compliant with UI behavior

### DIFF
--- a/app/code/Magento/BundleGraphQl/Model/Resolver/Links/Collection.php
+++ b/app/code/Magento/BundleGraphQl/Model/Resolver/Links/Collection.php
@@ -99,7 +99,9 @@ class Collection
 
         /** @var LinkCollection $linkCollection */
         $linkCollection = $this->linkCollectionFactory->create();
-        $linkCollection->setOptionIdsFilter($this->optionIds);
+        $linkCollection
+            ->setOptionIdsFilter($this->optionIds)
+            ->addFilterByRequiredOptions();
         $field = 'parent_product_id';
         foreach ($linkCollection->getSelect()->getPart('from') as $tableAlias => $data) {
             if ($data['tableName'] == $linkCollection->getTable('catalog_product_bundle_selection')) {

--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Variant/Collection.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Variant/Collection.php
@@ -150,7 +150,9 @@ class Collection
             $attributeData = $this->getAttributesCodes($product);
             /** @var ChildCollection $childCollection */
             $childCollection = $this->childCollectionFactory->create();
-            $childCollection->setProductFilter($product);
+            $childCollection
+                ->setProductFilter($product)
+                ->addFilterByRequiredOptions();
             $this->collectionProcessor->process(
                 $childCollection,
                 $this->searchCriteriaBuilder->create(),


### PR DESCRIPTION


### Description (*)
Fixed the issue `GraphQL response not compliant with UI behavior`

### Fixed Issues (if relevant)

1. Fixes magento/magento2#30921

### Manual testing scenarios (*)
1. Create or edit a Bundle or Configurable Product
2. Add products to bundle or configuration
3. Save the bundle/configuration.
4. Open one of the products previously added to the bundle/configuration
5. Add some customizable options and save the product
6. Open the bundle/configuration in the store Frontend. The item with customizable options is not displayed. This is normal behavior.
7. Query the bundle product via graphQL (example query below). The item with customizable options is part of the response. The response should reflect the UI behavior.
```
{
  products(filter: {url_key: {eq: "test-bundle"}}) {
    items {
      sku
      name
      ... on BundleProduct {
        items {
          option_id
          title
          options {
            id
            label
          }
        }
      }
    }
  }
}
```
```
{
  products(filter: {url_key: {eq: "chaz-kangeroo-hoodie"}}) {
    items {
      sku
      name
      ... on ConfigurableProduct {
        variants {
          product {
            sku
            name
          }
        }
      }
    }
  }
}

```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
